### PR TITLE
Profiler API WIP

### DIFF
--- a/src/groth16/mod.rs
+++ b/src/groth16/mod.rs
@@ -526,7 +526,8 @@ mod test_with_bls12_381 {
 
         let rng = &mut thread_rng();
 
-        let params = generate_random_parameters::<Bls12, _, _>(
+        let params = generate_random_parameters::<_, Bls12, _, _>(
+            &mut (),
             MySillyCircuit { a: None, b: None },
             rng
         ).unwrap();
@@ -553,6 +554,7 @@ mod test_with_bls12_381 {
             c.mul_assign(&b);
 
             let proof = create_random_proof(
+                &mut (),
                 MySillyCircuit {
                     a: Some(a),
                     b: Some(b)

--- a/src/groth16/tests/mod.rs
+++ b/src/groth16/tests/mod.rs
@@ -113,6 +113,7 @@ fn test_xordemo() {
         };
 
         generate_parameters(
+            &mut (),
             c,
             g1,
             g2,
@@ -303,6 +304,7 @@ fn test_xordemo() {
         };
 
         create_proof(
+            &mut (),
             c,
             &params,
             r,

--- a/tests/mimc.rs
+++ b/tests/mimc.rs
@@ -185,7 +185,7 @@ fn test_mimc() {
             constants: &constants
         };
 
-        generate_random_parameters(c, rng).unwrap()
+        generate_random_parameters(&mut (), c, rng).unwrap()
     };
 
     // Prepare the verification key (for proof verification)
@@ -221,7 +221,7 @@ fn test_mimc() {
             };
 
             // Create a groth16 proof with our parameters.
-            let proof = create_random_proof(c, &params, rng).unwrap();
+            let proof = create_random_proof(&mut (), c, &params, rng).unwrap();
 
             proof.write(&mut proof_vec).unwrap();
         }


### PR DESCRIPTION
WIP

This is to address #19 and any similar benchmarking and information collection.

The idea is that the concrete `ConstraintSystem` should provide a `.profiler()` method that returns a reference to a generic `Profiler`. Inside of synthesis, we'll have some kind of interface for benchmarking witnessing, but I haven't figured out how that should look yet. (It can probably partially piggyback on top of the existing namespacing!)

Anyway, the outer object should have some way to communicate information such as:

1. How many constraints were created?
2. How many public inputs and auxillary variables are there?
3. How long did witness generation take in total? (Note that any profiling inside of witness generation might produce overhead that this wouldn't know about. This and other things make me think there should be layers to the profiler abstraction, such as a subtrait that deals with profiling witness generation?)